### PR TITLE
Don't replace stdout with NSLogWriter

### DIFF
--- a/{{ cookiecutter.formal_name }}/{{ cookiecutter.formal_name }}/app_packages/nslog.py
+++ b/{{ cookiecutter.formal_name }}/{{ cookiecutter.formal_name }}/app_packages/nslog.py
@@ -83,5 +83,5 @@ class NSLogWriter(io.TextIOBase):
         return UTF16_NATIVE
 
 
-# Replace stdout and stderr with a single NSLogWriter
-sys.stdout = sys.stderr = NSLogWriter()
+# Replace stderr with a single NSLogWriter
+sys.stderr = NSLogWriter()


### PR DESCRIPTION
This PR closes #2 by not redirecting stdout to the NSLog. This has two advantages:

1. Command line tools bundled with briefcase now have access to stdout. I know that this is a niche application but it will be valuable to some (including myself :). We already include curses for this purpose which is useless when stdout ends up in the logs only. 
2. It is possible to see stdout output when running the main executable from the terminal.

`stderr` on the other hand (e.g., `logging.StreamHandler`, tracebacks, warning, etc) is well placed in the logs, even though one might argue that printing to the default stdout can still be valuable here as well...

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [ ] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
