### PR TITLE
Create CI tests based on the raw briefcase CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,140 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_call:
+
+env:
+  python_version: "3.9"
+
+defaults:
+  run:
+    shell: bash # https://github.com/beeware/briefcase/pull/912
+
+jobs:
+  pre-commit:
+    name: Pre-commit code style checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v3.1.0
+      - name: Set up Python
+        uses: actions/setup-python@v4.3.0
+        with:
+          python-version: ${{ env.python_version }}
+      - name: Lint with Pre-commit
+        uses: pre-commit/action@v3.0.0
+
+  towncrier:
+    runs-on: ubuntu-latest
+    steps:
+      # Fetch main branch for comparison, then check out current branch.
+      - uses: actions/checkout@v3.1.0
+        with:
+          fetch-depth: 0
+          ref: main
+      - uses: actions/checkout@v3.1.0
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4.3.0
+        with:
+          python-version: ${{ env.python_version }}
+      - run: pip install tox
+      - run: tox -e towncrier-check
+
+  verify-apps:
+    name: Build apps
+    strategy:
+      matrix:
+        os_name: ["macOS"]
+        framework: ["toga", "pyside2", "pyside6", "ppb"]
+        include:
+          - os_name: macOS
+            platform: macos-12
+            briefcase-data-dir: ~/Library/Caches/org.beeware.briefcase
+            pip-cache-dir: ~/Library/Caches/pip
+            docker-cache-dir: ~/Library/Containers/com.docker.docker/Data/vms/0/
+
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Cache Briefcase tools
+        uses: actions/cache@v3.0.11
+        with:
+          key: briefcase-${{ matrix.platform }}
+          path: |
+            ~/.cookiecutters
+            ${{ matrix.briefcase-data-dir }}
+            ${{ matrix.pip-cache-dir }}
+            ${{ matrix.docker-cache-dir }}
+      - uses: actions/checkout@v3.1.0
+        with:
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v4.3.0
+        with:
+          python-version: ${{ env.python_version }}
+      - name: Install system dependencies
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          sudo apt-get install -y flatpak flatpak-builder
+      - name: Get packages
+        uses: actions/download-artifact@v3
+        with:
+          name: packages
+          path: dist
+      - name: Install packages
+        run: pip install briefcase
+      - name: Create App
+        run: |
+          cd tests/apps
+          cat verify-${{ matrix.framework }}.config | briefcase new --template .
+      - name: Build App
+        run: |
+          cd tests/apps/verify-${{ matrix.framework }}
+          briefcase create
+          briefcase build
+          briefcase package --adhoc-sign
+      - name: Build Xcode project
+        if: matrix.os_name == 'macOS'
+        run: |
+          cd tests/apps/verify-${{ matrix.framework }}
+          briefcase create ${{ matrix.os_name }} Xcode
+          briefcase build ${{ matrix.os_name }} Xcode
+          briefcase package ${{ matrix.os_name }} Xcode --adhoc-sign
+      - name: Build Visual Studio project
+        if: matrix.os_name == 'windows'
+        run: |
+          cd tests/apps/verify-${{ matrix.framework }}
+          briefcase create ${{ matrix.os_name }} VisualStudio
+          briefcase build ${{ matrix.os_name }} VisualStudio
+          briefcase package ${{ matrix.os_name }} VisualStudio --adhoc-sign
+      - name: Build Flatpak project
+        if: matrix.os_name == 'linux' && matrix.framework == 'toga'
+        run: |
+          cd tests/apps/verify-${{ matrix.framework }}
+          briefcase create ${{ matrix.os_name }} flatpak
+          briefcase build ${{ matrix.os_name }} flatpak
+          briefcase package ${{ matrix.os_name }} flatpak --adhoc-sign
+      - name: Build Android App
+        if: matrix.framework == 'toga'
+        run: |
+          cd tests/apps/verify-${{ matrix.framework }}
+          briefcase create android
+          briefcase build android
+          briefcase package android --adhoc-sign
+      - name: Build iOS App
+        if: matrix.platform == 'macos-12' && matrix.framework == 'toga'
+        run: |
+          cd tests/apps/verify-${{ matrix.framework }}
+          briefcase create iOS
+          briefcase build iOS -d "iPhone SE (2nd generation)"
+          briefcase package iOS --adhoc-sign
+      - name: Build Web App
+        if: matrix.framework == 'toga'
+        run: |
+          cd tests/apps/verify-${{ matrix.framework }}
+          briefcase create web
+          briefcase build web
+          briefcase package web

--- a/tests/apps/verify-ppb.config
+++ b/tests/apps/verify-ppb.config
@@ -1,0 +1,10 @@
+Hello PPB
+verify-ppb
+org.beeware
+Hello PPB
+A PPB test app
+Brutus
+contact@beeware.org
+https://beeware.org/
+1
+4

--- a/tests/apps/verify-pyside2.config
+++ b/tests/apps/verify-pyside2.config
@@ -1,0 +1,10 @@
+Hello PySide2
+verify-pyside2
+org.beeware
+Hello PySide2
+A PySide2 test app
+Brutus
+contact@beeware.org
+https://beeware.org/
+1
+2

--- a/tests/apps/verify-pyside6.config
+++ b/tests/apps/verify-pyside6.config
@@ -1,0 +1,10 @@
+Hello PySide6
+verify-pyside6
+org.beeware
+Hello PySide6
+A PySide6 test app
+Brutus
+contact@beeware.org
+https://beeware.org/
+1
+3

--- a/tests/apps/verify-toga.config
+++ b/tests/apps/verify-toga.config
@@ -1,0 +1,10 @@
+Hello Toga
+verify-toga
+org.beeware
+Hello Toga
+A Toga test app
+Brutus
+contact@beeware.org
+https://beeware.org/
+1
+1


### PR DESCRIPTION
@freakboy3742 (sitting next to me) requested CI for the template repos, so I'm giving it a shot.

Rough idea:

1. copy the CI workflow and test configs from the main briefcase repo
2. Strip out bits that I don't _think_ we need (i.e. linux/windows and unit tests)
3. Edit the `briefcase new` command to specify a template dir
4. Pray it works

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [ ] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
