### PR TITLE
Set utf-8 mode during Python initialisation

### DIFF
--- a/{{ cookiecutter.formal_name }}/{{ cookiecutter.class_name }}/Info.plist
+++ b/{{ cookiecutter.formal_name }}/{{ cookiecutter.class_name }}/Info.plist
@@ -83,10 +83,5 @@
 		{% endfor %}
 	</array>
 	{% endif %}
-    <key>LSEnvironment</key>
-    <dict>
-        <key>LC_CTYPE</key>
-        <string>UTF-8</string>
-    </dict>
 </dict>
 </plist>

--- a/{{ cookiecutter.formal_name }}/{{ cookiecutter.class_name }}/main.m
+++ b/{{ cookiecutter.formal_name }}/{{ cookiecutter.class_name }}/main.m
@@ -15,8 +15,8 @@ NSString * format_traceback(PyObject *type, PyObject *value, PyObject *traceback
 int main(int argc, char *argv[]) {
     int ret = 0;
     PyStatus status;
-    PyConfig config;
     PyPreConfig preconfig;
+    PyConfig config;
     NSString *python_home;
     NSString *app_module_name;
     NSString *path;
@@ -39,8 +39,8 @@ int main(int argc, char *argv[]) {
 
         // Generate an isolated Python configuration.
         NSLog(@"Configuring isolated Python...");
-        PyConfig_InitIsolatedConfig(&config);
         PyPreConfig_InitIsolatedConfig(&preconfig);
+        PyConfig_InitIsolatedConfig(&config);
 
         // Configure the Python interpreter:
         // Enforce UTF-8 encoding for stderr, stdout, file-system encoding and locale.


### PR DESCRIPTION
Fixes #17 by:

* Setting utf-8 mode during Python initialisation. Note that `Py_PreInitialize` needs to be called before `PyConfig_Read` or any other methods which might already perform pre-initialisation for us.
* Remove the LC_CTYPE environment variable from Info.plist. It was no longer having any effect.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
