### PR TITLE
Add the ability to generate non-universal binaries.

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -10,6 +10,8 @@
     "build": "1",
     "document_types": {},
     "python_version": "3.X.0",
+    "universal_build": true,
+    "host_arch": "arm64",
     "_extensions": [
         "briefcase.integrations.cookiecutter.PythonVersionExtension"
     ]

--- a/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.xcodeproj/project.pbxproj
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.xcodeproj/project.pbxproj
@@ -349,7 +349,7 @@
 		0D354FDD2551BFBD009178D1 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD)";
+				ARCHS = "{% if cookiecutter.universal_build %}$(ARCHS_STANDARD){% else %}{{ cookiecutter.host_arch }}{% endif %}";
 				ASSETCATALOG_COMPILER_APPICON_NAME = "{{ cookiecutter.formal_name }}";
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -375,7 +375,7 @@
 		0D354FDE2551BFBD009178D1 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD)";
+				ARCHS = "{% if cookiecutter.universal_build %}$(ARCHS_STANDARD){% else %}{{ cookiecutter.host_arch }}{% endif %}";
 				ASSETCATALOG_COMPILER_APPICON_NAME = "{{ cookiecutter.formal_name }}";
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";


### PR DESCRIPTION
If a project flagged as being a non-universal binary, modify the Xcode architecture settings to generate a platform-specific binary.

Refs beeware/briefcase#1482
Refs beeware/briefcase#1492

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
