### PR TITLE
Correct the CFBundleIconFile entry

### DIFF
--- a/{{ cookiecutter.format }}/{{ cookiecutter.class_name }}/Info.plist
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.class_name }}/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>{{ cookiecutter.formal_name }}</string>
 	<key>CFBundleIconFile</key>
-	<string>{{ cookiecutter.formal_name }}</string>
+	<string>{{ cookiecutter.formal_name }}.icns</string>
 	<key>CFBundleIconName</key>
 	<string>{{ cookiecutter.formal_name }}</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
The CFBundleIconFile entry didn't include the filename extension; as a result, trying to load that file failed.

Refs beeware/toga#2558.

Requires a back port to the 0.3.18 template branch.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
