### PR TITLE
Modify the Xcode template to allow for console apps

### DIFF
--- a/{{ cookiecutter.format }}/installer/Distribution.xml
+++ b/{{ cookiecutter.format }}/installer/Distribution.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<installer-script minSpecVersion="1.000000">
+    <title>{{ cookiecutter.formal_name }}</title>
+    <welcome file="welcome.html" mime-type="text/html" />
+    <conclusion file="conclusion.html" mime-type="text/html" />
+    <license file="LICENSE" mime-type="text/plain" />
+    <options customize="never" allow-external-scripts="no"/>
+    <domains enable_localSystem="true" />
+    <choices-outline>
+        <line choice="{{ cookiecutter.app_name }}"/>
+    </choices-outline>
+    <choice id="{{ cookiecutter.app_name }}" title="{{ cookiecutter.app_name }}">
+        <pkg-ref id="{{ cookiecutter.app_name }}.pkg"/>
+    </choice>
+    <pkg-ref id="{{ cookiecutter.app_name }}.pkg" auth="Root">{{ cookiecutter.app_name }}.pkg</pkg-ref>
+</installer-script>

--- a/{{ cookiecutter.format }}/installer/resources/conclusion.html
+++ b/{{ cookiecutter.format }}/installer/resources/conclusion.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+      <style>
+      * {
+          font-family: sans-serif;
+      }
+      </style>
+  </head>
+  <body>
+    <h1>Install complete!</h1>
+    <p>Thank you for installing Hello Cmdline</p>
+  </body>
+</html>

--- a/{{ cookiecutter.format }}/installer/resources/welcome.html
+++ b/{{ cookiecutter.format }}/installer/resources/welcome.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+      <style>
+        * {
+            font-family: sans-serif;
+        }
+      </style>
+  </head>
+  <body>
+    <h1>Hello Cmdline installer</h1>
+    <p>You will be guided through the steps necessary to install this software.</p>
+  </body>
+</html>

--- a/{{ cookiecutter.format }}/installer/scripts/postinstall
+++ b/{{ cookiecutter.format }}/installer/scripts/postinstall
@@ -1,0 +1,7 @@
+#!/bin/sh
+echo "Post installation process started"
+
+echo "Install binary symlink"
+ln -si "/Library/{{ cookiecutter.formal_name }}/{{ cookiecutter.formal_name }}.app/Contents/MacOS/{{ cookiecutter.formal_name }}" /usr/local/bin/{{ cookiecutter.app_name }}
+
+echo "Post installation process finished"


### PR DESCRIPTION
A collection of template updates to support generating console apps:
* Modifies the bundle lookup process to support execution from a symlink to the main binary
* Adds metadata used when constructing a .pkg file

Once completed, the app template binary will need to be updated.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
