### PR TITLE
Bump support package revisions.

### DIFF
--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -11,11 +11,11 @@ entitlements_path = "{{ cookiecutter.class_name }}/{{ cookiecutter.app_name }}.e
 
 support_path = "Support"
 {{ {
-    "3.9": "support_revision = 14",
-    "3.10": "support_revision = 10",
-    "3.11": "support_revision = 5",
-    "3.12": "support_revision = 5",
-    "3.13": "support_revision = 2",
+    "3.9": "support_revision = 15",
+    "3.10": "support_revision = 11",
+    "3.11": "support_revision = 6",
+    "3.12": "support_revision = 6",
+    "3.13": "support_revision = 3",
 }.get(cookiecutter.python_version|py_tag, "") }}
 cleanup_paths = [
 ]


### PR DESCRIPTION
Updates the support package to the most recently published versions. These were published in October, but then never put into production - I'm not sure why. However, it does appear to include fixes that address a notarization issue that has been reported for Python 3.11 and earlier.

Refs beeware/briefcase#2090.

Requires back porting to 0.3.20 template.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
