### PR TITLE
Allow for runpy returning non-integer results.

### DIFF
--- a/{{ cookiecutter.format }}/{{ cookiecutter.class_name }}/main.m
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.class_name }}/main.m
@@ -251,15 +251,19 @@ int main(int argc, char *argv[]) {
                 if (PyErr_GivenExceptionMatches(exc_value, PyExc_SystemExit)) {
                     systemExit_code = PyObject_GetAttrString(exc_value, "code");
                     if (systemExit_code == NULL) {
-                        debug_log(@"Could not determine exit code");
+                        traceback_str = @"Could not determine exit code";
                         ret = -10;
+                    } else if (systemExit_code == Py_None) {
+                        // SystemExit with a code of None; documented as a
+                        // return code of 0.
+                        ret = 0;
                     } else if (PyLong_Check(systemExit_code)) {
                         // SystemExit with error code
                         ret = (int) PyLong_AsLong(systemExit_code);
                     } else {
-                        // SystemExit with a string for an error code. Use the
-                        // string as the traceback, and use the documented
-                        // SystemExit return value of 1.
+                        // Any other SystemExit value - convert to a string, and
+                        // use the string as the traceback, and use the
+                        // documented SystemExit return value of 1.
                         ret = 1;
                         traceback_str = [NSString stringWithUTF8String:PyUnicode_AsUTF8(PyObject_Str(systemExit_code))];
                     }

--- a/{{ cookiecutter.format }}/{{ cookiecutter.class_name }}/main.m
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.class_name }}/main.m
@@ -252,9 +252,18 @@ int main(int argc, char *argv[]) {
                     if (systemExit_code == NULL) {
                         debug_log(@"Could not determine exit code");
                         ret = -10;
-                    }
-                    else {
+                    } else if (PyLong_Check(systemExit_code)) {
+                        // SystemExit with error code
                         ret = (int) PyLong_AsLong(systemExit_code);
+                    } else {
+                        // Convert exit code to a string. This is required by runpy._error
+                        ret = -11;
+                        info_log(@"---------------------------------------------------------------------------");
+                        info_log(@"Application quit abnormally!");
+
+                        // Display exit message in the crash dialog.
+                        traceback_str = [NSString stringWithUTF8String:PyUnicode_AsUTF8(PyObject_Str(systemExit_code))];
+                        crash_dialog(traceback_str);
                     }
                 } else {
                     // Non-SystemExit; likely an uncaught exception

--- a/{{ cookiecutter.format }}/{{ cookiecutter.class_name }}/main.m
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.class_name }}/main.m
@@ -247,6 +247,7 @@ int main(int argc, char *argv[]) {
                     exit(-5);
                 }
 
+                traceback_str = NULL;
                 if (PyErr_GivenExceptionMatches(exc_value, PyExc_SystemExit)) {
                     systemExit_code = PyObject_GetAttrString(exc_value, "code");
                     if (systemExit_code == NULL) {
@@ -256,20 +257,22 @@ int main(int argc, char *argv[]) {
                         // SystemExit with error code
                         ret = (int) PyLong_AsLong(systemExit_code);
                     } else {
-                        // SystemExit with a string for an error code.
+                        // SystemExit with a string for an error code. Use the
+                        // string as the traceback, and use the documented
+                        // SystemExit return value of 1.
                         ret = 1;
+                        traceback_str = [NSString stringWithUTF8String:PyUnicode_AsUTF8(PyObject_Str(systemExit_code))];
                     }
                 } else {
                     // Non-SystemExit; likely an uncaught exception
-                    ret = -6;
-                }
-
-                if (ret != 0) {
                     info_log(@"---------------------------------------------------------------------------");
                     info_log(@"Application quit abnormally!");
-
-                    // Display stack trace in the crash dialog.
+                    ret = -6;
                     traceback_str = format_traceback(exc_type, exc_value, exc_traceback);
+                }
+
+                if (traceback_str != NULL) {
+                    // Display stack trace in the crash dialog.
                     crash_dialog(traceback_str);
                 }
             }

--- a/{{ cookiecutter.format }}/{{ cookiecutter.class_name }}/main.m
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.class_name }}/main.m
@@ -256,18 +256,15 @@ int main(int argc, char *argv[]) {
                         // SystemExit with error code
                         ret = (int) PyLong_AsLong(systemExit_code);
                     } else {
-                        // Convert exit code to a string. This is required by runpy._error
-                        ret = -11;
-                        info_log(@"---------------------------------------------------------------------------");
-                        info_log(@"Application quit abnormally!");
-
-                        // Display exit message in the crash dialog.
-                        traceback_str = [NSString stringWithUTF8String:PyUnicode_AsUTF8(PyObject_Str(systemExit_code))];
-                        crash_dialog(traceback_str);
+                        // SystemExit with a string for an error code.
+                        ret = 1;
                     }
                 } else {
                     // Non-SystemExit; likely an uncaught exception
                     ret = -6;
+                }
+
+                if (ret != 0) {
                     info_log(@"---------------------------------------------------------------------------");
                     info_log(@"Application quit abnormally!");
 


### PR DESCRIPTION
Fixes #64.

If runpy is able to unable to successfully find and run a module, it raises a SystemExit subclass (runpy._error) that returns a *string* as the code, with the string being the message of the exception that was raised trying to run the module. In the examples reported by #64, this is the text of the ImportError.

The existing template always tries to cast the code as a long, which fails, resulting in  `TypeError: 'str' object cannot be interpreted as an integer`. 

This PR only converts to an an integer if the object *is* a long; otherwise, it converts to a string and shows the crash dialog box. This results in the output:
```
[helloworld] Starting app...
===========================================================================
---------------------------------------------------------------------------
Application quit abnormally!
/Users/rkm/beeware/briefcase/local/tmp/helloworld/build/helloworld/macos/xcode/build/Release/Hello World.app/Contents/MacOS/Hello World: No module named helloworld.__main__; 'helloworld' is a package and cannot be directly executed
```

if `__main__.py` is missing, or
```
[helloworld] Starting app...
===========================================================================
---------------------------------------------------------------------------
Application quit abnormally!
/Users/rkm/beeware/briefcase/local/tmp/helloworld/build/helloworld/macos/xcode/build/Release/Hello World.app/Contents/MacOS/Hello World: No module named helloworld
```
if `helloworld` is a bare file. These messages are also displayed in the crash dialog.

Other errors (such as a ValueError or ImportError raised in the body of app.py) are unaffected, as they don't surface as a `SystemExit`.

Once merged, the stub binaries will need to be re-tagged and the app template bumped.

The same fix will also work for windows and Linux templates, so it should be ported.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
