### PR TITLE
Allow target macOS version to be customizable.

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -15,6 +15,7 @@
     "console_app": false,
     "universal_build": true,
     "host_arch": "arm64",
+    "min_os_version": "11.0",
     "_extensions": [
         "briefcase.integrations.cookiecutter.PythonVersionExtension",
         "briefcase.integrations.cookiecutter.PListExtension"

--- a/{{ cookiecutter.format }}/{{ cookiecutter.class_name }}/Info.plist
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.class_name }}/Info.plist
@@ -23,7 +23,7 @@
 	<key>CFBundleVersion</key>
 	<string>{{ cookiecutter.build }}</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>11.0</string>
+	<string>{{ cookiecutter.min_os_version }}</string>
 	<key>NSMainStoryboardFile</key>
 	<string>Main</string>
 	<key>NSPrincipalClass</key>

--- a/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.xcodeproj/project.pbxproj
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.xcodeproj/project.pbxproj
@@ -280,7 +280,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = {{ cookiecutter.min_os_version }};
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -340,7 +340,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = {{ cookiecutter.min_os_version }};
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "{{ cookiecutter.formal_name }}";
@@ -374,7 +374,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = {{ cookiecutter.min_os_version }};
 				PRODUCT_BUNDLE_IDENTIFIER = "{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 			};
@@ -407,7 +407,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MACOSX_DEPLOYMENT_TARGET = {{ cookiecutter.min_os_version }};
 				PRODUCT_BUNDLE_IDENTIFIER = "{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}";
 			};
 			name = Release;


### PR DESCRIPTION
Exposes the LSMinimumSystemVersion as a variable that can be configured, using the `min_os_version` setting.

Refs beeware/briefcase#2233.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
