### PR TITLE
Ensure /usr/local/bin exists for cmdline installs.

### DIFF
--- a/{{ cookiecutter.format }}/installer/scripts/postinstall
+++ b/{{ cookiecutter.format }}/installer/scripts/postinstall
@@ -1,6 +1,11 @@
 #!/bin/sh
 echo "Post installation process started"
 
+if [ ! -d "/usr/local/bin" ]; then
+    echo "Creating /usr/local/bin directory"
+    mkdir -p /usr/local/bin
+fi
+
 echo "Install binary symlink"
 ln -si "/Library/{{ cookiecutter.formal_name }}/{{ cookiecutter.formal_name }}.app/Contents/MacOS/{{ cookiecutter.formal_name }}" /usr/local/bin/{{ cookiecutter.app_name }}
 


### PR DESCRIPTION
Refs beeware/briefcase-macOS-app-template#79

Port of beeware/briefcase-macOS-app-template#80. Ensures that /usr/local/bin exists before attempting to create the symlink.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
