### PR TITLE
Cleanup xcframework content that can't be pushed to the app store.

### DIFF
--- a/{{ cookiecutter.format }}/briefcase.toml
+++ b/{{ cookiecutter.format }}/briefcase.toml
@@ -19,6 +19,8 @@ support_path = "Support"
     "3.14": "support_revision = 5",
 }.get(cookiecutter.python_version|py_tag, "") }}
 cleanup_paths = [
+    "Support/Python.xcframework/**/python*/config-*-darwin",
+    "Support/Python.xcframework/**/pkgconfig",
 ]
 icon.16 = "{{ cookiecutter.class_name }}/Assets.xcassets/{{ cookiecutter.formal_name }}.appiconset/icon-16.png"
 icon.32 = "{{ cookiecutter.class_name }}/Assets.xcassets/{{ cookiecutter.formal_name }}.appiconset/icon-32.png"


### PR DESCRIPTION
Adds cleanup paths to remove content that can't be used at runtime, and can't be shipped to the App Store.

These paths are already cleaned up on the macOS template; it was an oversight to not exclude the same content from the Xcode template. Unlike the app template, headers/includes must be retained as they're needed to build the Xcode project.

This should be backported to 0.3.24, as it prevents Xcode projects from being shipped to the App Store.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
