### PR TITLE
Ensure that locale is set on startup.

### DIFF
--- a/{{ cookiecutter.format }}/{{ cookiecutter.class_name }}/main.m
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.class_name }}/main.m
@@ -70,6 +70,8 @@ int main(int argc, char *argv[]) {
         // Enforce UTF-8 encoding for stderr, stdout, file-system encoding and locale.
         // See https://docs.python.org/3/library/os.html#python-utf-8-mode.
         preconfig.utf8_mode = 1;
+        // Ensure the locale is set (isolated interpreters won't by default)
+        preconfig.configure_locale = 1;
         // Don't buffer stdio. We want output to appears in the log immediately
         config.buffered_stdio = 0;
         // Don't write bytecode; we can't modify the app bundle


### PR DESCRIPTION
Refs beeware/briefcase-iOS-Xcode-template#57.

Ensures that locale is configured on interpreter startup (which isn't the default for an isolated environment).

Unlike beeware/briefcase-iOS-Xcode-template#57, it isn't necessary to set LANG, as the macOS environment will provide that.

App template binaries will need to be re-tagged when this is merged.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
