### PR TITLE
Switch to using macOS-26 runner.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     uses: beeware/.github/.github/workflows/app-build-verify.yml@main
     with:
       python-version: ${{ matrix.python-version }}
-      runner-os: macos-latest
+      runner-os: macos-26
       framework: ${{ matrix.framework }}
       target-platform: macOS
       target-format: Xcode

--- a/.github/workflows/update-binary.yml
+++ b/.github/workflows/update-binary.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build-stubs:
     name: Build stub binaries
-    runs-on: macos-latest
+    runs-on: macos-26
     strategy:
       matrix:
         python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]


### PR DESCRIPTION
In order to enable Liquid Glass effects, the binary used for an app needs to be compiled against the macOS 26 SDK.

This means the macOS stub binary needs to be compiled against the macOS 26 SDK; if it isn't, macOS 26 users won't get Liquid Glass effects in their GUIs. 

The easiest way to do this is to build the stub binary on the macOS 26 runner, which defaults to Xcode 26.

Fixes #95.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] All new features have been tested
- [x] All new features have been documented
- [x] I have read the **CONTRIBUTING.md** file
- [x] I will abide by the code of conduct
