### PR TITLE
Use correct logic for stdout check.

### DIFF
--- a/{{ cookiecutter.format }}/{{ cookiecutter.class_name }}/main.m
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.class_name }}/main.m
@@ -232,10 +232,10 @@ int main(int argc, char *argv[]) {
                 exit(-15);
             }
 
-            {# if cookiecutter.python_version|minor_version < 14 and not cookiecutter.console_app -#}
+            {% if cookiecutter.python_version|minor_version < 14 and not cookiecutter.console_app -%}
             // Set up any stdout/stderr handling that is required
             setup_stdout(mainBundle);
-            {# endif -#}
+            {% endif -%}
 
             // Start the app module.
             //


### PR DESCRIPTION
The logic for stdout checks on Python 3.14 was using comment syntax, rather than `if` syntax.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
