### PR TITLE
Allow for using a non-framework Python library.

### DIFF
--- a/.github/workflows/check-pr-template.yml
+++ b/.github/workflows/check-pr-template.yml
@@ -9,4 +9,4 @@ permissions: {}
 jobs:
   check-pr-template:
     name: Check PR template
-    uses: beeware/.github/.github/workflows/pr-checklist.yml@43aab4a46c7db630ef1bfe817c120677ffa5548e  # main
+    uses: beeware/.github/.github/workflows/pr-checklist.yml@741cc5a311012ee0ee195938889a337449d01eeb  # main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
   pre-commit:
     name: Pre-commit checks
     uses: beeware/.github/.github/workflows/pre-commit-run.yml@741cc5a311012ee0ee195938889a337449d01eeb  # main
+    permissions:
+      contents: read
     with:
       pre-commit-source: pre-commit
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,14 +23,16 @@ permissions: {}
 jobs:
   pre-commit:
     name: Pre-commit checks
-    uses: beeware/.github/.github/workflows/pre-commit-run.yml@43aab4a46c7db630ef1bfe817c120677ffa5548e  # main
+    uses: beeware/.github/.github/workflows/pre-commit-run.yml@741cc5a311012ee0ee195938889a337449d01eeb  # main
     with:
       pre-commit-source: pre-commit
 
   verify-apps:
     name: Build apps
     needs: pre-commit
-    uses: beeware/.github/.github/workflows/app-build-verify.yml@43aab4a46c7db630ef1bfe817c120677ffa5548e  # main
+    uses: beeware/.github/.github/workflows/app-build-verify.yml@741cc5a311012ee0ee195938889a337449d01eeb  # main
+    permissions:
+      contents: read
     with:
       python-version: ${{ matrix.python-version }}
       runner-os: macos-15

--- a/.github/workflows/update-binary.yml
+++ b/.github/workflows/update-binary.yml
@@ -58,9 +58,7 @@ jobs:
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip
-        # TODO: use the WIP branch to build until the feature is finalized.
-        # python -m pip install git+https://github.com/beeware/briefcase.git
-        python -m pip install git+https://github.com/freakboy3742/briefcase.git@add-conda-support
+        python -m pip install git+https://github.com/beeware/briefcase.git
 
     - name: Create Framework stub app
       if: ${{ matrix.framework }}

--- a/.github/workflows/update-binary.yml
+++ b/.github/workflows/update-binary.yml
@@ -54,8 +54,8 @@ jobs:
         # TEMP: use the WIP branch to build
         python -m pip install git+https://github.com/freakboy3742/briefcase.git@alt-env-support
 
-    - name: Generate Framework stub app
-      if: ${{ !matrix.framework }}
+    - name: Create Framework stub app
+      if: ${{ matrix.framework }}
       run: |
         # Generate the stub app
         cd stub
@@ -70,7 +70,6 @@ jobs:
 
     - name: Build Stub App
       run: |
-        # Generate the stub app
         cd stub
         briefcase build macOS Xcode
 

--- a/.github/workflows/update-binary.yml
+++ b/.github/workflows/update-binary.yml
@@ -57,7 +57,7 @@ jobs:
       run: |
         # Generate the stub app
         cd stub
-        briefcase create macOS Xcode -C env_manager=${{ !matrix.framework && 'conda' || 'pip' }}
+        briefcase create macOS Xcode -C env_manager=\"${{ !matrix.framework && 'conda' || 'pip' }}\"
         briefcase build macOS Xcode
 
         echo "Build ${{ env.PYTHON_TAG }}-${{ env.BUILD_NUMBER }} ${{ !matrix.framework && 'non-framework' || 'framework' }} console stub artefact"

--- a/.github/workflows/update-binary.yml
+++ b/.github/workflows/update-binary.yml
@@ -74,14 +74,14 @@ jobs:
         briefcase build macOS Xcode
 
         echo "Build ${{ env.PYTHON_TAG }}-${{ env.BUILD_NUMBER }} ${{ !matrix.framework && 'non-framework' || 'framework' }} console stub artefact"
-        mv "./build/console-stub/macos/xcode/build/Release/Console Stub.app/Contents/MacOS/Console Stub" ${{ env.STUB_PREFIX }}Stub
-        codesign --remove-signature ${{ env.STUB_PREFIX }}Stub
-        zip Console-${{ env.STUB_PREFIX }}Stub-${{ env.PYTHON_TAG }}-${{ env.BUILD_NUMBER }}.zip ${{ env.STUB_PREFIX }}Stub
+        mv "./build/console-stub/macos/xcode/build/Release/Console Stub.app/Contents/MacOS/Console Stub" Stub
+        codesign --remove-signature Stub
+        zip Console-${{ env.STUB_PREFIX }}Stub-${{ env.PYTHON_TAG }}-${{ env.BUILD_NUMBER }}.zip Stub
 
         echo "Build ${{ env.PYTHON_TAG }}-${{ env.BUILD_NUMBER }} ${{ !matrix.framework && 'non-framework' || 'framework' }} GUI stub artefact"
-        mv "./build/gui-stub/macos/xcode/build/Release/GUI Stub.app/Contents/MacOS/GUI Stub" ${{ env.STUB_PREFIX }}Stub
-        codesign --remove-signature ${{ env.STUB_PREFIX }}Stub
-        zip GUI-${{ env.STUB_PREFIX }}Stub-${{ env.PYTHON_TAG }}-${{ env.BUILD_NUMBER }}.zip ${{ env.STUB_PREFIX }}Stub
+        mv "./build/gui-stub/macos/xcode/build/Release/GUI Stub.app/Contents/MacOS/GUI Stub" Stub
+        codesign --remove-signature Stub
+        zip GUI-${{ env.STUB_PREFIX }}Stub-${{ env.PYTHON_TAG }}-${{ env.BUILD_NUMBER }}.zip Stub
 
         echo "Stub binaries:"
         ls -1 *.zip

--- a/.github/workflows/update-binary.yml
+++ b/.github/workflows/update-binary.yml
@@ -10,8 +10,6 @@ jobs:
   build-stubs:
     name: Build stub binaries
     runs-on: macos-26
-    permissions:
-      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -60,7 +58,7 @@ jobs:
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip
-        # TEMP: use the WIP branch to build
+        # TODO: use the WIP branch to build until
         python -m pip install git+https://github.com/freakboy3742/briefcase.git@alt-env-support
 
     - name: Create Framework stub app

--- a/.github/workflows/update-binary.yml
+++ b/.github/workflows/update-binary.yml
@@ -34,6 +34,9 @@ jobs:
         echo "BUILD_NUMBER=${BUILD_NUMBER}" | tee -a $GITHUB_ENV
         echo "STUB_PREFIX=${STUB_PREFIX}" | tee -a $GITHUB_ENV
 
+        # Expose BUILD_NUMBER as a step output so it can be consumed as a job output
+        echo "BUILD_NUMBER=${BUILD_NUMBER}" | tee -a $GITHUB_OUTPUT
+
     - name: Checkout Template
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       with:

--- a/.github/workflows/update-binary.yml
+++ b/.github/workflows/update-binary.yml
@@ -24,7 +24,7 @@ jobs:
       run: |
         export BUILD_NUMBER=$(basename $TAG_NAME)
         export PYTHON_TAG=$(python -c "print('${{ matrix.python-version }}'.split('-')[0])")
-        export STUB_PREFIX=${{ matrix.framework && 'L' || '' }}
+        export STUB_PREFIX=${{ !matrix.framework && 'L' || '' }}
 
         echo "PYTHON_TAG=${PYTHON_TAG}" | tee -a $GITHUB_ENV
         echo "BUILD_NUMBER=${BUILD_NUMBER}" | tee -a $GITHUB_ENV
@@ -54,11 +54,24 @@ jobs:
         # TEMP: use the WIP branch to build
         python -m pip install git+https://github.com/freakboy3742/briefcase.git@alt-env-support
 
-    - name: Generate Xcode App Template
+    - name: Generate Framework stub app
+      if: ${{ !matrix.framework }}
       run: |
         # Generate the stub app
         cd stub
-        briefcase create macOS Xcode -C env_manager=\"${{ !matrix.framework && 'conda' || 'pip' }}\"
+        briefcase create macOS Xcode
+
+    - name: Create Non-framework stub app
+      if: ${{ !matrix.framework }}
+      run: |
+        # Generate the stub app
+        cd stub
+        briefcase create macOS Xcode -C env_manager=\"conda\" -C universal_build=false
+
+    - name: Build Stub App
+      run: |
+        # Generate the stub app
+        cd stub
         briefcase build macOS Xcode
 
         echo "Build ${{ env.PYTHON_TAG }}-${{ env.BUILD_NUMBER }} ${{ !matrix.framework && 'non-framework' || 'framework' }} console stub artefact"

--- a/.github/workflows/update-binary.yml
+++ b/.github/workflows/update-binary.yml
@@ -9,6 +9,7 @@ jobs:
     name: Build stub binaries
     runs-on: macos-26
     strategy:
+      fail-fast: false
       matrix:
         python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
         framework: [true, false]

--- a/.github/workflows/update-binary.yml
+++ b/.github/workflows/update-binary.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip
-        # TODO: use the WIP branch to build until
+        # TODO: use the WIP branch to build until the feature is finalized.
         python -m pip install git+https://github.com/freakboy3742/briefcase.git@alt-env-support
 
     - name: Create Framework stub app

--- a/.github/workflows/update-binary.yml
+++ b/.github/workflows/update-binary.yml
@@ -115,7 +115,7 @@ jobs:
 
   make-release:
     name: Make Release
-    runs-on: macOS-latest
+    runs-on: macos-26
     needs: [ build-stubs ]
     permissions:
       contents: write

--- a/.github/workflows/update-binary.yml
+++ b/.github/workflows/update-binary.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
+        framework: [true, false]
     outputs:
       BUILD_NUMBER: ${{ steps.build-vars.outputs.BUILD_NUMBER }}
 
@@ -22,39 +23,52 @@ jobs:
       run: |
         export BUILD_NUMBER=$(basename $TAG_NAME)
         export PYTHON_TAG=$(python -c "print('${{ matrix.python-version }}'.split('-')[0])")
+        export STUB_PREFIX=${{ matrix.framework && "L" else "" }}
 
         echo "PYTHON_TAG=${PYTHON_TAG}" | tee -a $GITHUB_ENV
         echo "BUILD_NUMBER=${BUILD_NUMBER}" | tee -a $GITHUB_ENV
+        echo "STUB_PREFIX=${STUB_PREFIX}" | tee -a $GITHUB_ENV
 
     - name: Checkout Template
       uses: actions/checkout@v6.0.3
 
     - name: Setup Python ${{ matrix.python-version }}
+      if: ${{ matrix.framework }}
       uses: actions/setup-python@v6.2.0
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
 
+    - name: Setup Miniconda
+      if: ${{ !matrix.framework }}
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+        auto-update-conda: true
+        activate-environment: briefcase-env
+
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install git+https://github.com/beeware/briefcase.git
+        # TEMP: use the WIP branch to build
+        python -m pip install git+https://github.com/freakboy3742/briefcase.git@alt-env-support
 
     - name: Generate Xcode App Template
       run: |
         # Generate the stub app
         cd stub
+        briefcase create macOS Xcode -C env_manager=${{ !matrix.framework && "conda" || "pip" }}
         briefcase build macOS Xcode
 
-        echo "Build ${{ env.PYTHON_TAG }}-${{ env.BUILD_NUMBER }} console stub artefact"
-        mv "./build/console-stub/macos/xcode/build/Release/Console Stub.app/Contents/MacOS/Console Stub" Stub
-        codesign --remove-signature Stub
-        zip Console-Stub-${{ env.PYTHON_TAG }}-${{ env.BUILD_NUMBER }}.zip Stub
+        echo "Build ${{ env.PYTHON_TAG }}-${{ env.BUILD_NUMBER }} ${{ !matrix.framework && "non-framework" || "framework" }} console stub artefact"
+        mv "./build/console-stub/macos/xcode/build/Release/Console Stub.app/Contents/MacOS/Console Stub" ${{ env.STUB_PREFIX }}Stub
+        codesign --remove-signature ${{ env.STUB_PREFIX }}Stub
+        zip Console-${{ env.STUB_PREFIX }}Stub-${{ env.PYTHON_TAG }}-${{ env.BUILD_NUMBER }}.zip ${{ env.STUB_PREFIX }}Stub
 
-        echo "Build ${{ env.PYTHON_TAG }}-${{ env.BUILD_NUMBER }} GUI stub artefact"
-        mv "./build/gui-stub/macos/xcode/build/Release/GUI Stub.app/Contents/MacOS/GUI Stub" Stub
-        codesign --remove-signature Stub
-        zip GUI-Stub-${{ env.PYTHON_TAG }}-${{ env.BUILD_NUMBER }}.zip Stub
+        echo "Build ${{ env.PYTHON_TAG }}-${{ env.BUILD_NUMBER }} ${{ !matrix.framework && "non-framework" || "framework" }} GUI stub artefact"
+        mv "./build/gui-stub/macos/xcode/build/Release/GUI Stub.app/Contents/MacOS/GUI Stub" ${{ env.STUB_PREFIX }}Stub
+        codesign --remove-signature ${{ env.STUB_PREFIX }}Stub
+        zip GUI-${{ env.STUB_PREFIX }}Stub-${{ env.PYTHON_TAG }}-${{ env.BUILD_NUMBER }}.zip ${{ env.STUB_PREFIX }}Stub
 
         echo "Stub binaries:"
         ls -1 *.zip
@@ -62,7 +76,7 @@ jobs:
     - name: Upload build artefacts
       uses: actions/upload-artifact@v7.0.1
       with:
-        name: ${{ env.PYTHON_TAG }}-stubs
+        name: ${{ env.PYTHON_TAG }}-${{ env.STUB_PREFIX }}Stubs
         path: stub/*.zip
 
     - name: Upload Release Asset to S3
@@ -74,8 +88,8 @@ jobs:
         python -m pip install -U setuptools
         python -m pip install awscli
 
-        aws s3 cp stub/Console-Stub-${{ env.PYTHON_TAG }}-${{ env.BUILD_NUMBER }}.zip s3://briefcase-support/python/${{ env.PYTHON_TAG }}/macOS/Console-Stub-${{ env.PYTHON_TAG }}-${{ env.BUILD_NUMBER }}.zip
-        aws s3 cp stub/GUI-Stub-${{ env.PYTHON_TAG }}-${{ env.BUILD_NUMBER }}.zip s3://briefcase-support/python/${{ env.PYTHON_TAG }}/macOS/GUI-Stub-${{ env.PYTHON_TAG }}-${{ env.BUILD_NUMBER }}.zip
+        aws s3 cp stub/Console-${{ env.STUB_PREFIX }}Stub-${{ env.PYTHON_TAG }}-${{ env.BUILD_NUMBER }}.zip s3://briefcase-support/python/${{ env.PYTHON_TAG }}/macOS/Console-${{ env.STUB_PREFIX }}Stub-${{ env.PYTHON_TAG }}-${{ env.BUILD_NUMBER }}.zip
+        aws s3 cp stub/GUI-${{ env.STUB_PREFIX }}Stub-${{ env.PYTHON_TAG }}-${{ env.BUILD_NUMBER }}.zip s3://briefcase-support/python/${{ env.PYTHON_TAG }}/macOS/GUI-${{ env.STUB_PREFIX }}Stub-${{ env.PYTHON_TAG }}-${{ env.BUILD_NUMBER }}.zip
 
   make-release:
     name: Make Release

--- a/.github/workflows/update-binary.yml
+++ b/.github/workflows/update-binary.yml
@@ -23,7 +23,7 @@ jobs:
       run: |
         export BUILD_NUMBER=$(basename $TAG_NAME)
         export PYTHON_TAG=$(python -c "print('${{ matrix.python-version }}'.split('-')[0])")
-        export STUB_PREFIX=${{ matrix.framework && "L" else "" }}
+        export STUB_PREFIX=${{ matrix.framework && 'L' || '' }}
 
         echo "PYTHON_TAG=${PYTHON_TAG}" | tee -a $GITHUB_ENV
         echo "BUILD_NUMBER=${BUILD_NUMBER}" | tee -a $GITHUB_ENV
@@ -57,15 +57,15 @@ jobs:
       run: |
         # Generate the stub app
         cd stub
-        briefcase create macOS Xcode -C env_manager=${{ !matrix.framework && "conda" || "pip" }}
+        briefcase create macOS Xcode -C env_manager=${{ !matrix.framework && 'conda' || 'pip' }}
         briefcase build macOS Xcode
 
-        echo "Build ${{ env.PYTHON_TAG }}-${{ env.BUILD_NUMBER }} ${{ !matrix.framework && "non-framework" || "framework" }} console stub artefact"
+        echo "Build ${{ env.PYTHON_TAG }}-${{ env.BUILD_NUMBER }} ${{ !matrix.framework && 'non-framework' || 'framework' }} console stub artefact"
         mv "./build/console-stub/macos/xcode/build/Release/Console Stub.app/Contents/MacOS/Console Stub" ${{ env.STUB_PREFIX }}Stub
         codesign --remove-signature ${{ env.STUB_PREFIX }}Stub
         zip Console-${{ env.STUB_PREFIX }}Stub-${{ env.PYTHON_TAG }}-${{ env.BUILD_NUMBER }}.zip ${{ env.STUB_PREFIX }}Stub
 
-        echo "Build ${{ env.PYTHON_TAG }}-${{ env.BUILD_NUMBER }} ${{ !matrix.framework && "non-framework" || "framework" }} GUI stub artefact"
+        echo "Build ${{ env.PYTHON_TAG }}-${{ env.BUILD_NUMBER }} ${{ !matrix.framework && 'non-framework' || 'framework' }} GUI stub artefact"
         mv "./build/gui-stub/macos/xcode/build/Release/GUI Stub.app/Contents/MacOS/GUI Stub" ${{ env.STUB_PREFIX }}Stub
         codesign --remove-signature ${{ env.STUB_PREFIX }}Stub
         zip GUI-${{ env.STUB_PREFIX }}Stub-${{ env.PYTHON_TAG }}-${{ env.BUILD_NUMBER }}.zip ${{ env.STUB_PREFIX }}Stub

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -16,6 +16,7 @@
     "universal_build": true,
     "host_arch": "arm64",
     "min_os_version": "11.0",
+    "use_framework": true,
     "_extensions": [
         "briefcase.integrations.cookiecutter.PythonVersionExtension",
         "briefcase.integrations.cookiecutter.PListExtension"

--- a/stub/pyproject.toml
+++ b/stub/pyproject.toml
@@ -10,11 +10,11 @@ template = ".."
 
 [tool.briefcase.app.gui-stub]
 formal_name = "GUI Stub"
-description = "A stub binary for GUI apps that can be integrated into the macOS app template"
+description = "A stub binary for macOS GUI apps"
 sources = ['src/gui_stub']
 
 [tool.briefcase.app.console-stub]
 formal_name = "Console Stub"
-description = "A stub binary for console apps that can be integrated into the macOS app template"
+description = "A stub binary for macOS console apps"
 sources = ['src/console_stub']
 console_app = true

--- a/{{ cookiecutter.format }}/{{ cookiecutter.class_name }}/main.m
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.class_name }}/main.m
@@ -5,7 +5,11 @@
 #import <Foundation/Foundation.h>
 #import <AppKit/AppKit.h>
 #import <Cocoa/Cocoa.h>
+{%- if cookiecutter.use_framework %}
 #import <Python/Python.h>
+{%- else %}
+#import <Python.h>
+{%- endif %}
 #include <dlfcn.h>
 #include <libgen.h>
 #include <mach-o/dyld.h>
@@ -96,7 +100,11 @@ int main(int argc, char *argv[]) {
 
         // Set the home for the Python interpreter
         python_tag = @"{{ cookiecutter.python_version|py_tag }}";
+{%- if cookiecutter.use_framework %}
         python_home = [NSString stringWithFormat:@"%@/Python.framework/Versions/%@", frameworksPath, python_tag, nil];
+{%- else %}
+        python_home = [NSString stringWithFormat:@"%@/python/", resourcePath, nil];
+{%- endif %}
         debug_log(@"PythonHome: %@", python_home);
         wtmp_str = Py_DecodeLocale([python_home UTF8String], NULL);
         status = PyConfig_SetString(&config, &config.home, wtmp_str);

--- a/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.xcodeproj/project.pbxproj
+++ b/{{ cookiecutter.format }}/{{ cookiecutter.formal_name }}.xcodeproj/project.pbxproj
@@ -14,8 +14,12 @@
 		0D354FEF2551C249009178D1 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0D354FEE2551C249009178D1 /* Cocoa.framework */; };
 		0D7B44A82555E01500CBC44B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0D7B44A72555E01500CBC44B /* Foundation.framework */; };
 		0D7B44DA2556C84100CBC44B /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D354FD72551BFBD009178D1 /* main.m */; };
+{%- if cookiecutter.use_framework %}
 		6060E7722AF0B40500C04AE0 /* Python.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6060E76F2AF0B14D00C04AE0 /* Python.xcframework */; };
 		6060E7732AF0B40500C04AE0 /* Python.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6060E76F2AF0B14D00C04AE0 /* Python.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+{%- else %}
+		AA0000022AF0B40500C04AE0 /* libpython{{ cookiecutter.python_version|py_tag }}.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = AA0000012AF0B14D00C04AE0 /* libpython{{ cookiecutter.python_version|py_tag }}.dylib */; };
+{%- endif %}
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -29,6 +33,7 @@
 			name = "Embed Foundation Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+{%- if cookiecutter.use_framework %}
 		6060E7742AF0B40500C04AE0 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
@@ -40,6 +45,7 @@
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+{%- endif %}
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
@@ -53,7 +59,11 @@
 		0D354FE52551C1E1009178D1 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = System/Library/Frameworks/AppKit.framework; sourceTree = SDKROOT; };
 		0D354FEE2551C249009178D1 /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = System/Library/Frameworks/Cocoa.framework; sourceTree = SDKROOT; };
 		0D7B44A72555E01500CBC44B /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+{%- if cookiecutter.use_framework %}
 		6060E76F2AF0B14D00C04AE0 /* Python.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = Python.xcframework; sourceTree = "<group>"; };
+{%- else %}
+		AA0000012AF0B14D00C04AE0 /* libpython{{ cookiecutter.python_version|py_tag }}.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libpython{{ cookiecutter.python_version|py_tag }}.dylib; path = Python/lib/libpython{{ cookiecutter.python_version|py_tag }}.dylib; sourceTree = "<group>"; };
+{%- endif %}
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -64,7 +74,11 @@
 				0D354FE62551C1E1009178D1 /* AppKit.framework in Frameworks */,
 				0D354FEF2551C249009178D1 /* Cocoa.framework in Frameworks */,
 				0D7B44A82555E01500CBC44B /* Foundation.framework in Frameworks */,
+{%- if cookiecutter.use_framework %}
 				6060E7722AF0B40500C04AE0 /* Python.xcframework in Frameworks */,
+{%- else %}
+				AA0000022AF0B40500C04AE0 /* libpython{{ cookiecutter.python_version|py_tag }}.dylib in Frameworks */,
+{%- endif %}
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -115,7 +129,11 @@
 		60A04BBB28AF5E1000DAA9E5 /* Support */ = {
 			isa = PBXGroup;
 			children = (
+{%- if cookiecutter.use_framework %}
 				6060E76F2AF0B14D00C04AE0 /* Python.xcframework */,
+{%- else %}
+				AA0000012AF0B14D00C04AE0 /* libpython{{ cookiecutter.python_version|py_tag }}.dylib */,
+{%- endif %}
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -131,7 +149,11 @@
 				0D354FC52551BFBA009178D1 /* Frameworks */,
 				0D354FC62551BFBA009178D1 /* Resources */,
 				0D7B44EB2556C8B800CBC44B /* Embed Foundation Extensions */,
+{%- if cookiecutter.use_framework %}
 				6060E7742AF0B40500C04AE0 /* Embed Frameworks */,
+{%- else %}
+				AA0000032AF0B40500C04AE0 /* Embed Python lib */,
+{%- endif %}
 				60A04BC128AF640400DAA9E5 /* Sign Python Binary Modules */,
 			);
 			buildRules = (
@@ -150,7 +172,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
-				LastUpgradeCheck = 1540;
+				LastUpgradeCheck = 2660;
 				ORGANIZATIONNAME = "{{ cookiecutter.author }}";
 				TargetAttributes = {
 					0D354FC72551BFBA009178D1 = {
@@ -190,6 +212,27 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+{%- if not cookiecutter.use_framework %}
+		AA0000032AF0B40500C04AE0 /* Embed Python lib */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Embed Python lib";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -e\nDEST=\"$BUILT_PRODUCTS_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH/python\"\necho \"Embedding Python lib into $DEST\"\nmkdir -p \"$DEST\"\n# Copy the entire lib/ tree, preserving symlinks. Exclude static archives\n# and pkgconfig metadata that are not needed at runtime.\nrsync -a --delete --copy-unsafe-links \\\n    --exclude='*.a' \\\n    --exclude='pkgconfig' \\\n    \"$PROJECT_DIR/Support/Python/lib/\" \"$DEST/lib/\"\n";
+		};
+{%- endif %}
 		60A04BC128AF640400DAA9E5 /* Sign Python Binary Modules */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -286,6 +329,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_NAME = "{{ cookiecutter.formal_name }}";
 				SDKROOT = macosx;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 			};
 			name = Debug;
 		};
@@ -345,6 +389,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "{{ cookiecutter.formal_name }}";
 				SDKROOT = macosx;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 			};
 			name = Release;
 		};
@@ -363,17 +408,37 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				DEAD_CODE_STRIPPING = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
+{%- if cookiecutter.use_framework %}
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(PROJECT_DIR)/Support\"",
 				);
+{%- else %}
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+{%- endif %}
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+{%- if cookiecutter.use_framework %}
 				HEADER_SEARCH_PATHS = "\"$(BUILT_PRODUCTS_DIR)/Python.framework/Headers\"";
+{%- else %}
+				HEADER_SEARCH_PATHS = "\"$(PROJECT_DIR)/Support/Python/include/python{{ cookiecutter.python_version|py_tag }}\"";
+{%- endif %}
 				INFOPLIST_FILE = "{{ cookiecutter.class_name }}/Info.plist";
+{%- if cookiecutter.use_framework %}
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+{%- else %}
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@executable_path/../Resources/python/lib",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(PROJECT_DIR)/Support/Python/lib\"",
+				);
+{%- endif %}
 				MACOSX_DEPLOYMENT_TARGET = {{ cookiecutter.min_os_version }};
 				PRODUCT_BUNDLE_IDENTIFIER = "{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -396,17 +461,37 @@
 				DEAD_CODE_STRIPPING = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_TESTABILITY = YES;
+{%- if cookiecutter.use_framework %}
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(PROJECT_DIR)/Support\"",
 				);
+{%- else %}
+				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
+{%- endif %}
 				GCC_C_LANGUAGE_STANDARD = gnu99;
+{%- if cookiecutter.use_framework %}
 				HEADER_SEARCH_PATHS = "\"$(BUILT_PRODUCTS_DIR)/Python.framework/Headers\"";
+{%- else %}
+				HEADER_SEARCH_PATHS = "\"$(PROJECT_DIR)/Support/Python/include/python{{ cookiecutter.python_version|py_tag }}\"";
+{%- endif %}
 				INFOPLIST_FILE = "{{ cookiecutter.class_name }}/Info.plist";
+{%- if cookiecutter.use_framework %}
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+{%- else %}
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@executable_path/../Resources/python/lib",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(PROJECT_DIR)/Support/Python/lib\"",
+				);
+{%- endif %}
 				MACOSX_DEPLOYMENT_TARGET = {{ cookiecutter.min_os_version }};
 				PRODUCT_BUNDLE_IDENTIFIER = "{{ cookiecutter.bundle }}.{{ cookiecutter.app_name }}";
 			};


### PR DESCRIPTION
Allow for projects where the environment manager is responsible for providing Python, and thus provides a "non-framework" Python.

This means linking against a `lib/libpython3.x.so`, rather than a `Python.framework`; and setting the PYTHONHOME to point to the lib location.

beeware/briefcase#2972 will need to be merged before the changes in this PR can be used to tag a new binary

Refs beeware/briefcase#2972.

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
