### PR TITLE
Update Github Actions configuration.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,22 @@
-
 version: 2
+
+multi-ecosystem-groups:
+  dependencies:
+    schedule:
+      # Check for updates on the first Sunday of every month, 8PM UTC
+      interval: "cron"
+      cronjob: "0 20 * * sun#1"
+
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
-    schedule:
-      # Check for updates on the first Sunday of every month, 8PM UTC
-      interval: "cron"
-      cronjob: "0 20 * * sun#1"
+    patterns: ["*"]
+    multi-ecosystem-group: "dependencies"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "pre-commit"
     directory: "/"
-    schedule:
-      # Check for updates on the first Sunday of every month, 8PM UTC
-      interval: "cron"
-      cronjob: "0 20 * * sun#1"
+    patterns: ["*"]
+    multi-ecosystem-group: "dependencies"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/check-pr-template.yml
+++ b/.github/workflows/check-pr-template.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [opened, edited, reopened, synchronize]
 
+permissions: {}
+
 jobs:
   check-pr-template:
     name: Check PR template

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
   pre-commit:
     name: Pre-commit checks
     uses: beeware/.github/.github/workflows/pre-commit-run.yml@main
+    permissions:
+      contents: read
     with:
       pre-commit-source: pre-commit
 
@@ -29,6 +31,8 @@ jobs:
     name: Build apps
     needs: pre-commit
     uses: beeware/.github/.github/workflows/app-build-verify.yml@main
+    permissions:
+      contents: read
     with:
       python-version: ${{ matrix.python-version }}
       runner-os: macos-15

--- a/.github/workflows/new-issue.yml
+++ b/.github/workflows/new-issue.yml
@@ -7,12 +7,14 @@ on:
       - reopened
       - transferred
 
+permissions: {}
+
 jobs:
   add-to-project:
     name: Add issue to BeeWare project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v2.0.0
+      - uses: actions/add-to-project@5afcf98fcd03f1c2f92c3c83f58ae24323cc57fd # v2.0.0
         with:
           project-url: https://github.com/orgs/beeware/projects/1
           github-token: ${{ secrets.BRUTUS_PAT_TOKEN }}

--- a/.github/workflows/update-binary.yml
+++ b/.github/workflows/update-binary.yml
@@ -4,11 +4,14 @@ on:
     tags:
     - 'b*'
 
+permissions: {}
+
 jobs:
   build-stubs:
     name: Build stub binaries
     runs-on: macos-26
     strategy:
+      fail-fast: false
       matrix:
         python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
     outputs:
@@ -26,11 +29,16 @@ jobs:
         echo "PYTHON_TAG=${PYTHON_TAG}" | tee -a $GITHUB_ENV
         echo "BUILD_NUMBER=${BUILD_NUMBER}" | tee -a $GITHUB_ENV
 
+        # Expose BUILD_NUMBER as a step output so it can be consumed as a job output
+        echo "BUILD_NUMBER=${BUILD_NUMBER}" | tee -a $GITHUB_OUTPUT
+
     - name: Checkout Template
-      uses: actions/checkout@v7.0.0
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      with:
+        persist-credentials: false
 
     - name: Setup Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6.3.0
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6.3.0
       with:
         python-version: ${{ matrix.python-version }}
         allow-prereleases: true
@@ -46,21 +54,21 @@ jobs:
         cd stub
         briefcase build macOS Xcode
 
-        echo "Build ${{ env.PYTHON_TAG }}-${{ env.BUILD_NUMBER }} console stub artefact"
+        echo "Build ${PYTHON_TAG}-${BUILD_NUMBER} console stub artefact"
         mv "./build/console-stub/macos/xcode/build/Release/Console Stub.app/Contents/MacOS/Console Stub" Stub
         codesign --remove-signature Stub
-        zip Console-Stub-${{ env.PYTHON_TAG }}-${{ env.BUILD_NUMBER }}.zip Stub
+        zip Console-Stub-${PYTHON_TAG}-${BUILD_NUMBER}.zip Stub
 
-        echo "Build ${{ env.PYTHON_TAG }}-${{ env.BUILD_NUMBER }} GUI stub artefact"
+        echo "Build ${PYTHON_TAG}-${BUILD_NUMBER} GUI stub artefact"
         mv "./build/gui-stub/macos/xcode/build/Release/GUI Stub.app/Contents/MacOS/GUI Stub" Stub
         codesign --remove-signature Stub
-        zip GUI-Stub-${{ env.PYTHON_TAG }}-${{ env.BUILD_NUMBER }}.zip Stub
+        zip GUI-Stub-${PYTHON_TAG}-${BUILD_NUMBER}.zip Stub
 
         echo "Stub binaries:"
         ls -1 *.zip
 
     - name: Upload build artefacts
-      uses: actions/upload-artifact@v7.0.1
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
       with:
         name: ${{ env.PYTHON_TAG }}-stubs
         path: stub/*.zip
@@ -74,29 +82,31 @@ jobs:
         python -m pip install -U setuptools
         python -m pip install awscli
 
-        aws s3 cp stub/Console-Stub-${{ env.PYTHON_TAG }}-${{ env.BUILD_NUMBER }}.zip s3://briefcase-support/python/${{ env.PYTHON_TAG }}/macOS/Console-Stub-${{ env.PYTHON_TAG }}-${{ env.BUILD_NUMBER }}.zip
-        aws s3 cp stub/GUI-Stub-${{ env.PYTHON_TAG }}-${{ env.BUILD_NUMBER }}.zip s3://briefcase-support/python/${{ env.PYTHON_TAG }}/macOS/GUI-Stub-${{ env.PYTHON_TAG }}-${{ env.BUILD_NUMBER }}.zip
+        aws s3 cp stub/Console-Stub-${PYTHON_TAG}-${BUILD_NUMBER}.zip s3://briefcase-support/python/${PYTHON_TAG}/macOS/Console-Stub-${PYTHON_TAG}-${BUILD_NUMBER}.zip
+        aws s3 cp stub/GUI-Stub-${PYTHON_TAG}-${BUILD_NUMBER}.zip s3://briefcase-support/python/${PYTHON_TAG}/macOS/GUI-Stub-${PYTHON_TAG}-${BUILD_NUMBER}.zip
 
   make-release:
     name: Make Release
-    runs-on: macOS-latest
+    runs-on: macos-26
     needs: [ build-stubs ]
+    permissions:
+      contents: write
     steps:
     - name: Get build artifacts
-      uses: actions/download-artifact@v8.0.1
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
       with:
         path: dist
         merge-multiple: true
 
     - name: Create Release
-      uses: ncipollo/release-action@v1.21.0
-      with:
-        name: ${{ needs.build-stubs.outputs.BUILD_NUMBER }}
-        tag: ${{ needs.build-stubs.outputs.BUILD_NUMBER }}
-        draft: true
-        body: |
-          Build ${{ needs.build-stubs.outputs.BUILD_NUMBER }} of the Briefcase macOS stub binary.
-
-          Includes support for Python 3.10-3.14.
-
-        artifacts: "dist/*"
+      env:
+        GH_TOKEN: ${{ github.token }}
+        GH_REPO: ${{ github.repository }}
+        BUILD_NUMBER: ${{ needs.build-stubs.outputs.BUILD_NUMBER }}
+      run: |
+        gh release create "${BUILD_NUMBER}" \
+          --title "${BUILD_NUMBER}" \
+          --notes "$(printf 'Build %s of the Briefcase macOS stub binary.\n\nIncludes support for Python 3.10-3.14.\n' "${BUILD_NUMBER}")" \
+          --draft \
+          --verify-tag \
+          dist/*

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,9 @@
+rules:
+  unpinned-uses:
+    config:
+      # Allow BeeWare-provided actions to be unpinned. If an attacker is in a
+      # position to exploit those action, they're probably able to exploit
+      # repositories directly; and it's significantly easier for our internal
+      # actions to automatically be the most recent versions.
+      policies:
+        beeware/*: ref-pin


### PR DESCRIPTION
Multiple updates to the GitHub Actions configuration:

* Adds a cooldown to Dependabot
* Merges dependabot into 
* Adds zizmor verification (including a pinning rule exemption for beeware/* actions)

Fixes #128
Fixes #129
Fixes #130

## PR Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I will abide by the BeeWare Code of Conduct
- [x] I have read and have followed the **CONTRIBUTING.md** file
- [ ] This PR was generated or assisted using an AI tool
